### PR TITLE
Add delete card functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ coverage/
 
 # Markdown
 mdx/
+
+# AI Coding Assistant
+.augment/

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -198,7 +198,9 @@ export const CARDS_MESSAGES = {
   REACTION_NOT_FOUND: 'Reaction not found',
   REACTION_ID_MUST_BE_STRING: 'Reaction id must be a string',
 
-  REACT_CARD_COMMENT_SUCCESS: 'Reacted to card comment successfully'
+  REACT_CARD_COMMENT_SUCCESS: 'Reacted to card comment successfully',
+
+  DELETE_CARD_SUCCESS: 'Card deleted successfully'
 }
 
 export const MEDIAS_MESSAGES = {

--- a/src/controllers/cards.controllers.ts
+++ b/src/controllers/cards.controllers.ts
@@ -9,6 +9,7 @@ import {
   UpdateCardReqBody
 } from '~/models/requests/Card.requests'
 import { TokenPayload } from '~/models/requests/User.requests'
+import Card from '~/models/schemas/Card.schema'
 import cardsService from '~/services/cards.services'
 
 export const createCardController = async (req: Request<ParamsDictionary, any, CreateCardReqBody>, res: Response) => {
@@ -35,4 +36,13 @@ export const reactToCardCommentController = async (
   const result = await cardsService.reactToCardComment({ card_id, user_id, comment_id, body: req.body })
 
   return res.json({ message: CARDS_MESSAGES.REACT_CARD_COMMENT_SUCCESS, result })
+}
+
+export const deleteCardController = async (req: Request<CardParams, any, any>, res: Response) => {
+  const { card_id } = req.params
+  const column_id = (req.card as Card & { column_id: string }).column_id
+
+  await cardsService.deleteCard(card_id, column_id)
+
+  return res.json({ message: CARDS_MESSAGES.DELETE_CARD_SUCCESS })
 }

--- a/src/routes/cards.routes.ts
+++ b/src/routes/cards.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import {
   createCardController,
+  deleteCardController,
   reactToCardCommentController,
   updateCardController
 } from '~/controllers/cards.controllers'
@@ -38,5 +39,7 @@ cardsRouter.put(
   filterMiddleware<ReactToCardCommentReqBody>(['action', 'emoji', 'reaction_id']),
   wrapRequestHandler(reactToCardCommentController)
 )
+
+cardsRouter.delete('/:card_id', accessTokenValidator, cardIdValidator, wrapRequestHandler(deleteCardController))
 
 export default cardsRouter

--- a/src/services/cards.services.ts
+++ b/src/services/cards.services.ts
@@ -240,6 +240,18 @@ class CardsService {
 
     return updatedCard
   }
+
+  async deleteCard(card_id: string, column_id: string) {
+    // Delete the card
+    await databaseService.cards.deleteOne({ _id: new ObjectId(card_id) })
+
+    // Delete the card_id from the card_order_ids of the column containing the card
+    await databaseService.columns.findOneAndUpdate(
+      { _id: new ObjectId(column_id) },
+      { $pull: { card_order_ids: new ObjectId(card_id) } },
+      { returnDocument: 'after' }
+    )
+  }
 }
 
 const cardsService = new CardsService()


### PR DESCRIPTION
Implements the endpoint to delete a card. This change introduces a new `DELETE /api/cards/:card_id` route.

The service layer handles the deletion by:
- Removing the card document from the database.
- Pulling the card's ID from the `card_order_ids` array of the parent column to maintain data integrity.