### PR TITLE
Implement get workspace details functionality

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -78,7 +78,12 @@ export const WORKSPACES_MESSAGES = {
   WORKSPACE_DESCRIPTION_MUST_BE_STRING: 'Workspace description must be a string',
   WORKSPACE_DESCRIPTION_MUST_BE_BETWEEN_3_AND_256: 'Workspace description must be between 3 and 256 characters',
 
-  CREATE_WORKSPACE_SUCCESS: 'Workspace created successfully'
+  CREATE_WORKSPACE_SUCCESS: 'Workspace created successfully',
+
+  INVALID_WORKSPACE_ID: 'Invalid workspace id',
+  WORKSPACE_NOT_FOUND: 'Workspace not found',
+
+  GET_WORKSPACE_SUCCESS: 'Get workspace successfully'
 }
 
 export const BOARDS_MESSAGES = {

--- a/src/controllers/workspaces.controllers.ts
+++ b/src/controllers/workspaces.controllers.ts
@@ -13,3 +13,8 @@ export const createWorkspaceController = async (
   const result = await workspacesService.createWorkspace(user_id, req.body)
   return res.json({ message: WORKSPACES_MESSAGES.CREATE_WORKSPACE_SUCCESS, result })
 }
+
+export const getWorkspaceController = async (req: Request<ParamsDictionary, any, any>, res: Response) => {
+  const result = { ...req.workspace }
+  return res.json({ message: WORKSPACES_MESSAGES.GET_WORKSPACE_SUCCESS, result })
+}

--- a/src/middlewares/workspaces.middlewares.ts
+++ b/src/middlewares/workspaces.middlewares.ts
@@ -1,5 +1,13 @@
+import { Request } from 'express'
 import { checkSchema } from 'express-validator'
+import { ObjectId } from 'mongodb'
+import { envConfig } from '~/config/environment'
+import HTTP_STATUS from '~/constants/httpStatus'
 import { WORKSPACES_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { TokenPayload } from '~/models/requests/User.requests'
+import Workspace from '~/models/schemas/Workspace.schema'
+import databaseService from '~/services/database.services'
 import { validate } from '~/utils/validation'
 
 export const createWorkspaceValidator = validate(
@@ -25,5 +33,148 @@ export const createWorkspaceValidator = validate(
       }
     },
     ['body']
+  )
+)
+
+export const workspaceIdValidator = validate(
+  checkSchema(
+    {
+      workspace_id: {
+        custom: {
+          options: async (value, { req }) => {
+            if (!ObjectId.isValid(value)) {
+              throw new ErrorWithStatus({
+                status: HTTP_STATUS.BAD_REQUEST,
+                message: WORKSPACES_MESSAGES.INVALID_WORKSPACE_ID
+              })
+            }
+
+            const { user_id } = (req as Request).decoded_authorization as TokenPayload
+
+            const queryConditions = [
+              { _id: new ObjectId(value) },
+              { _destroy: false },
+              {
+                'members.user_id': new ObjectId(user_id)
+              }
+            ]
+
+            // Execute MongoDB aggregation pipeline to fetch workspace with related data
+            const [workspace] = await databaseService.workspaces
+              .aggregate<Workspace>([
+                // Stage 1: $match - Filter documents based on query conditions
+                // This stage finds the workspace by ID, ensures it's not destroyed,
+                // and verifies the current user is a member of the workspace
+                {
+                  $match: { $and: queryConditions }
+                },
+                // Stage 2: $lookup - Join with boards collection
+                // This performs a left outer join to fetch all boards associated with this workspace
+                // localField: '_id' (workspace ID) matches foreignField: 'workspace_id' in boards collection
+                {
+                  $lookup: {
+                    from: envConfig.dbBoardsCollection,
+                    localField: '_id',
+                    foreignField: 'workspace_id',
+                    as: 'boards'
+                  }
+                },
+                // Stage 3: $lookup - Join with users collection for member details
+                // This fetches user information for all workspace members
+                // Uses a sub-pipeline to exclude sensitive user data (passwords, tokens)
+                {
+                  $lookup: {
+                    from: envConfig.dbUsersCollection,
+                    localField: 'members.user_id', // Array of user IDs from workspace members
+                    foreignField: '_id', // User document _id field
+                    as: 'memberUsers', // Store results in temporary field
+                    pipeline: [
+                      {
+                        // Sub-pipeline: $project - Exclude sensitive user fields
+                        // This ensures passwords and security tokens are not returned
+                        $project: {
+                          password: 0,
+                          email_verify_token: 0,
+                          forgot_password_token: 0
+                        }
+                      }
+                    ]
+                  }
+                },
+                // Stage 4: $addFields - Transform and flatten member data structure
+                // This stage restructures the members array to include user details directly
+                {
+                  $addFields: {
+                    members: {
+                      // $map - Transform each element in the members array
+                      $map: {
+                        input: '$members', // Process each member in the array
+                        as: 'member', // Variable name for current member
+                        in: {
+                          // $let - Define variables for use in expression
+                          $let: {
+                            vars: {
+                              // Find the corresponding user document for this member
+                              user: {
+                                // $arrayElemAt - Get the first element from filtered array
+                                $arrayElemAt: [
+                                  {
+                                    // $filter - Find user document matching member's user_id
+                                    $filter: {
+                                      input: '$memberUsers', // Search in fetched user documents
+                                      as: 'user', // Variable name for current user
+                                      cond: {
+                                        // $eq - Match user._id with member.user_id
+                                        $eq: ['$$user._id', '$$member.user_id']
+                                      }
+                                    }
+                                  },
+                                  0 // Get first (and only) matching element
+                                ]
+                              }
+                            },
+                            in: {
+                              // $mergeObjects - Combine member and user data into single object
+                              $mergeObjects: [
+                                {
+                                  // $unsetField - Remove user_id field from member object
+                                  // This prevents duplication since user._id will serve as identifier
+                                  $unsetField: {
+                                    field: 'user_id',
+                                    input: '$$member'
+                                  }
+                                },
+                                '$$user' // Merge all user fields into member object
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                // Stage 5: $project - Clean up temporary fields
+                // Remove the temporary 'memberUsers' field as it's no longer needed
+                {
+                  $project: { memberUsers: 0 }
+                }
+              ])
+              .toArray()
+
+            if (!workspace) {
+              throw new ErrorWithStatus({
+                status: HTTP_STATUS.NOT_FOUND,
+                message: WORKSPACES_MESSAGES.WORKSPACE_NOT_FOUND
+              })
+            }
+
+            ;(req as Request).workspace = workspace
+
+            return true
+          }
+        }
+      }
+    },
+    ['params']
   )
 )

--- a/src/routes/workspaces.routes.ts
+++ b/src/routes/workspaces.routes.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express'
-import { createWorkspaceController } from '~/controllers/workspaces.controllers'
+import { createWorkspaceController, getWorkspaceController } from '~/controllers/workspaces.controllers'
 import { accessTokenValidator } from '~/middlewares/auth.middlewares'
 import { verifiedUserValidator } from '~/middlewares/users.middlewares'
-import { createWorkspaceValidator } from '~/middlewares/workspaces.middlewares'
+import { createWorkspaceValidator, workspaceIdValidator } from '~/middlewares/workspaces.middlewares'
 import { wrapRequestHandler } from '~/utils/handlers'
 
 const workspacesRouter = Router()
@@ -13,6 +13,14 @@ workspacesRouter.post(
   verifiedUserValidator,
   createWorkspaceValidator,
   wrapRequestHandler(createWorkspaceController)
+)
+
+workspacesRouter.get(
+  '/:workspace_id',
+  accessTokenValidator,
+  verifiedUserValidator,
+  workspaceIdValidator,
+  wrapRequestHandler(getWorkspaceController)
 )
 
 export default workspacesRouter

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -5,6 +5,7 @@ import Card from '~/models/schemas/Card.schema'
 import Column from '~/models/schemas/Column.schema'
 import Invitation from '~/models/schemas/Invitation.schema'
 import User from '~/models/schemas/User.schema'
+import Workspace from '~/models/schemas/Workspace.schema'
 
 declare module 'express' {
   interface Request {
@@ -20,5 +21,6 @@ declare module 'express' {
     card?: Card
     invitee?: User
     invitation?: Invitation
+    workspace?: Workspace
   }
 }


### PR DESCRIPTION
This pull request introduces the API endpoint and associated logic to retrieve a single workspace by its ID.

- **`src/constants/messages.ts`**: Added new messages for `INVALID_WORKSPACE_ID`, `WORKSPACE_NOT_FOUND`, and `GET_WORKSPACE_SUCCESS`.
- **`src/controllers/workspaces.controllers.ts`**: Implemented `getWorkspaceController` to handle the request and return workspace data.
- **`src/middlewares/workspaces.middlewares.ts`**: Added `workspaceIdValidator` middleware. This validator performs:
    - Validation of `workspace_id` as a valid `ObjectId`.
    - Authorization check to ensure the requesting user is a member of the workspace.
    - MongoDB aggregation pipeline to fetch the workspace along with its associated boards and detailed member information (excluding sensitive user data).
    - Attaches the fetched workspace object to the request for controller use.
- **`src/routes/workspaces.routes.ts`**: Registered the new GET `/workspaces/:workspace_id` route, applying `accessTokenValidator`, `verifiedUserValidator`, and `workspaceIdValidator`.
- **`src/type.d.ts`**: Augmented the Express `Request` interface to include a `workspace` property for type safety.