### PR TITLE
Implement delete workspace functionality and validation

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -90,7 +90,9 @@ export const WORKSPACES_MESSAGES = {
   WORKSPACE_TYPE_MUST_BE_PUBLIC_OR_PRIVATE: 'Workspace type must be public or private',
   WORKSPACE_LOGO_MUST_BE_STRING: 'Workspace logo must be a string',
 
-  UPDATE_WORKSPACE_SUCCESS: 'Workspace updated successfully'
+  UPDATE_WORKSPACE_SUCCESS: 'Workspace updated successfully',
+
+  DELETE_WORKSPACE_SUCCESS: 'Workspace deleted successfully'
 }
 
 export const BOARDS_MESSAGES = {

--- a/src/controllers/workspaces.controllers.ts
+++ b/src/controllers/workspaces.controllers.ts
@@ -46,3 +46,11 @@ export const updateWorkspaceController = async (
   const result = await workspacesService.updateWorkspace(workspace_id, req.body)
   return res.json({ message: WORKSPACES_MESSAGES.UPDATE_WORKSPACE_SUCCESS, result })
 }
+
+export const deleteWorkspaceController = async (req: Request<WorkspaceParams, any, any>, res: Response) => {
+  const { workspace_id } = req.params
+
+  await workspacesService.deleteWorkspace(workspace_id)
+
+  return res.json({ message: WORKSPACES_MESSAGES.DELETE_WORKSPACE_SUCCESS })
+}

--- a/src/models/schemas/Board.schema.ts
+++ b/src/models/schemas/Board.schema.ts
@@ -7,7 +7,7 @@ interface BoardSchema {
   description?: string
   type: BoardType
   cover_photo?: string
-  workspace_id: ObjectId
+  workspace_id: ObjectId | null
   column_order_ids?: ObjectId[]
   owners: ObjectId[]
   members?: ObjectId[]
@@ -22,7 +22,7 @@ export default class Board {
   description: string
   type: BoardType
   cover_photo: string
-  workspace_id: ObjectId
+  workspace_id: ObjectId | null
   column_order_ids: ObjectId[]
   owners: ObjectId[]
   members: ObjectId[]
@@ -38,7 +38,7 @@ export default class Board {
     this.description = board.description || ''
     this.type = board.type || BoardType.Public
     this.cover_photo = board.cover_photo || ''
-    this.workspace_id = board.workspace_id
+    this.workspace_id = board.workspace_id || null
     this.column_order_ids = board.column_order_ids || []
     this.owners = board.owners || []
     this.members = board.members || []

--- a/src/routes/workspaces.routes.ts
+++ b/src/routes/workspaces.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import {
   createWorkspaceController,
+  deleteWorkspaceController,
   getWorkspaceController,
   getWorkspacesController,
   updateWorkspaceController
@@ -44,6 +45,14 @@ workspacesRouter.put(
   updateWorkspaceValidator,
   filterMiddleware<UpdateWorkspaceReqBody>(['title', 'description', 'type', 'logo']),
   wrapRequestHandler(updateWorkspaceController)
+)
+
+workspacesRouter.delete(
+  '/:workspace_id',
+  accessTokenValidator,
+  verifiedUserValidator,
+  workspaceIdValidator,
+  wrapRequestHandler(deleteWorkspaceController)
 )
 
 export default workspacesRouter

--- a/src/services/workspaces.services.ts
+++ b/src/services/workspaces.services.ts
@@ -56,6 +56,20 @@ class WorkspacesService {
 
     return workspace
   }
+
+  async deleteWorkspace(workspace_id: string) {
+    // Delete the workspace
+    await databaseService.workspaces.deleteOne({ _id: new ObjectId(workspace_id) })
+
+    // Move all Boards in that Workspace to the `closed` state (i.e., set `_destroy` to `true`) and set `workspace_id` to `null`.
+    await databaseService.boards.updateMany(
+      { workspace_id: new ObjectId(workspace_id) },
+      {
+        $set: { _destroy: true, workspace_id: null },
+        $currentDate: { updated_at: true }
+      }
+    )
+  }
 }
 
 const workspacesService = new WorkspacesService()


### PR DESCRIPTION
This pull request introduces the ability to delete workspaces, including the following changes:

- Adds a new `DELETE_WORKSPACE_SUCCESS` message constant.
- Implements `deleteWorkspaceController` to handle workspace deletion requests.
- Updates `Board.schema.ts` to allow `workspace_id` to be `null`, enabling boards to be disassociated from a workspace upon deletion.
- Adds a new DELETE route for workspaces in `workspaces.routes.ts`.
- Implements `deleteWorkspace` service method to:
  - Delete the specified workspace.
  - Set all boards associated with the deleted workspace to `_destroy: true` (soft delete) and `workspace_id: null`.